### PR TITLE
Add gitpod button ➕

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ To build an image, just
 ```bash
 docker build .
 ```
+# open repo in gitpod 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/samczsun/ethereum-transaction-viewer-frontend)
+
+- If button is not visible then click - [https://gitpod.io/#https://github.com/samczsun/ethereum-transaction-viewer-frontend](https://gitpod.io/#https://github.com/samczsun/ethereum-transaction-viewer-frontend)
+
+- This will open this repository in a [Gitpod Instance](https://www.gitpod.io/) and 
+  - Will build the repo 
+  - Start and serve on port 3000 


### PR DESCRIPTION
# Motivation 

1. Adding a button that opens the repo in an online IDE with a free tier for quick testing without the need of performing any environment setup activities. Online IDE being -  [gitpod](https://gitpod.io/).
- This is quite a common method of opening a repo , which can be seen in [THIS](https://github.com/scaffold-eth/scaffold-eth) popular repo.  

# Impact 

1. NIL - No changes to actual source code of core files. 
3. Addition of markdown ONLY. 
4. When an instance is opened in gitpod,  a un important `.gitpod.yml` file is created with the following setup script.

```sh 
# This configuration file was automatically generated by Gitpod.
# Please adjust to your needs (see https://www.gitpod.io/docs/config-gitpod-file)
# and commit this file to your remote git repository to share the goodness with others.

tasks:
  - init: pnpm install && pnpm run build
    command: pnpm run start
```

## Demo 

[DEMO VID](https://www.dropbox.com/s/ulwalx9tmd5szys/ST.mp4?dl=0) - Of opening the repo in gitpod, downloadable , hosted on dropbox

