### PR TITLE
Instead of requesting price for native token use the 0x address

### DIFF
--- a/components/value-change/ValueChange.tsx
+++ b/components/value-change/ValueChange.tsx
@@ -6,7 +6,7 @@ import React, { useContext } from 'react';
 import { SpanIconButton } from '../SpanIconButton';
 import { BigNumber, ethers } from 'ethers';
 import { NATIVE_TOKEN } from '../decoder/actions';
-import {findAffectedContract, formatUsd} from '../helpers';
+import { findAffectedContract, formatUsd } from '../helpers';
 import { DataRenderer } from '../DataRenderer';
 import { ChainConfigContext } from '../Chains';
 import { fetchDefiLlamaPrices, getPriceOfToken, PriceMetadataContext, toDefiLlamaId } from '../metadata/prices';
@@ -188,7 +188,9 @@ const computeBalanceChanges = (
                     } catch (e) {
                         console.error('failed to process value change', e);
                     }
-                } else if (traceLog.topics[0] === '0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65') {
+                } else if (
+                    traceLog.topics[0] === '0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65'
+                ) {
                     const [parentNode] = findAffectedContract(traceMetadata, traceLog);
 
                     try {
@@ -238,7 +240,10 @@ export const ValueChange = (props: ValueChangeProps) => {
 
     fetchDefiLlamaPrices(
         priceMetadata.updater,
-        Array.from(allTokens).map((token) => `${chainConfig.defillamaPrefix}:${token}`),
+        Array.from(allTokens).map((token) => {
+            const tokenAddress = token === NATIVE_TOKEN ? ethers.constants.AddressZero : token;
+            return `${chainConfig.defillamaPrefix}:${tokenAddress}`;
+        }),
         transactionMetadata.block.timestamp,
     );
     fetchTokenMetadata(tokenMetadata.updater, provider, Array.from(allTokens));


### PR DESCRIPTION
The current version of the app in `ValueChange` is requesting some prices on DefiLlama.

If the token is `NATIVE_TOKEN` it will try to call this endpoint `https://coins.llama.fi/prices/current/fantom:native_token`
On DefiLlama, you have two options

1) use `coingecko:<coinGeckoID>`
2) use the `0x` address directly to get the native token price for a network. In this example, it would be `https://coins.llama.fi/prices/current/fantom:0x0000000000000000000000000000000000000000`

I don't have the full knowledge of the codebase so probably other part of the codes should be changed.