### PR TITLE
Add Görli testnet via Ankr

### DIFF
--- a/components/Chains.ts
+++ b/components/Chains.ts
@@ -23,6 +23,16 @@ export const SupportedChains = [
         blockexplorerUrl: 'https://etherscan.io',
     },
     {
+        id: 'goerli',
+        displayName: 'Görli Testnet',
+        nativeTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        nativeSymbol: 'ETH',
+        coingeckoId: 'coingecko:ethereum',
+        defillamaPrefix: 'ethereum',
+        rpcUrl: 'https://rpc.ankr.com/eth_goerli',
+        blockexplorerUrl: 'https://goerli.etherscan.io',
+    },
+    {
         id: 'polygon',
         displayName: 'Polygon Mainnet',
         nativeTokenAddress: '0x0eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',


### PR DESCRIPTION
Since Ankr also has an option for Görli/Goerli, I feel like there are no drawbacks to this, unless I'm missing something. 

Defilama/Coingecko does not have gETH, so I kept the ETH symbol and ethereum as the prefix/ID.

Thanks!
-8x4