### PR TITLE
fix select network menu

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -116,6 +116,7 @@ function Navbar() {
                         <select
                             className="outline-1 outline outline-[#0000002d] py-2 px-3 mr-[1px]"
                             onChange={(event) => setChain(event.target.value)}
+                            value={chain}
                         >
                             {queryChain && !Array.isArray(queryChain) && queryChain.startsWith('conduit') ? (
                                 <option key={queryChain} value={queryChain} selected>


### PR DESCRIPTION
When I click link of transaction in other network (eg, https://tx.eth.samczsun.com/avalanche/0x3fa3ec2bd48d0e5ae6504cc536406fe067ecf779e5edb4e61ea36dec19cba495), I found the network menu didn't change.

In this PR, I add value to fix this issue.

BTW, what are these lines for?

```
{queryChain && !Array.isArray(queryChain) && queryChain.startsWith('conduit') ? (
    <option key={queryChain} value={queryChain} selected>
        {queryChain}
    </option>
) : (
    <></>
)}
```